### PR TITLE
Fix killing current session without detaching

### DIFF
--- a/scripts/kill_session_prompt.sh
+++ b/scripts/kill_session_prompt.sh
@@ -7,6 +7,6 @@ CURRENT_SESSION_NAME="$1"
 CURRENT_SESSION_ID="$2"
 
 main() {
-	tmux confirm -p "kill-session ${CURRENT_SESSION_NAME}? (y/n)" "run '$CURRENT_DIR/kill_session.sh \'$CURRENT_SESSION_ID\''"
+	tmux confirm -p "kill-session ${CURRENT_SESSION_NAME}? (y/n)" "run '$CURRENT_DIR/kill_session.sh \'$CURRENT_SESSION_ID''"
 }
 main


### PR DESCRIPTION
For some reason `tmux run-shell` requires weird syntax when it comes to shell
substitutions. Because of that session number passed to `kill_session.sh`
always had `\` character at the end. This in turn caused not closing the
session, as this invalid session number was used during session killing.