### PR TITLE
Fix prefix matching on session names

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -40,8 +40,12 @@ tmux_socket() {
 	echo $TMUX | cut -d',' -f1
 }
 
-session_exists() {
-	tmux has-session -t="$SESSION_NAME" >/dev/null 2>&1
+session_exists_exact() {
+	tmux has-session -t "=${SESSION_NAME}" >/dev/null 2>&1
+}
+
+session_exists_prefix() {
+	tmux has-session -t "$SESSION_NAME" >/dev/null 2>&1
 }
 
 switch_to_session() {

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -41,7 +41,7 @@ tmux_socket() {
 }
 
 session_exists() {
-	tmux has-session -t "$SESSION_NAME" >/dev/null 2>&1
+	tmux has-session -t="$SESSION_NAME" >/dev/null 2>&1
 }
 
 switch_to_session() {

--- a/scripts/new_session.sh
+++ b/scripts/new_session.sh
@@ -14,7 +14,7 @@ session_name_not_provided() {
 create_new_tmux_session() {
 	if session_name_not_provided; then
 		exit 0
-	elif session_exists; then
+	elif session_exists_exact; then
 		switch_to_session "$SESSION_NAME"
 		display_message "Switched to existing session ${SESSION_NAME}" "2000"
 	else

--- a/scripts/switch_or_loop.sh
+++ b/scripts/switch_or_loop.sh
@@ -19,7 +19,7 @@ main() {
 		dismiss_session_list_page_from_view
 		exit 0
 	fi
-	if session_exists; then
+	if session_exists_prefix; then
 		dismiss_session_list_page_from_view
 		tmux switch-client -t "$SESSION_NAME"
 	else


### PR DESCRIPTION
Session names were not doing exact matching so an attempt to create a
new session 'trunk' would fail when you already have a session called
'trunk-topic'. By using 'has-session -t=' we can do exact matching.