### PR TITLE
Denote {gif,pdf,png} as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 # Force text files to have unix eols, so Windows/Cygwin does not break them
 *.* eol=lf
+
+*.gif binary
+*.pdf binary
+*.png binary


### PR DESCRIPTION
Ensure that git does not convert CRLF to LF in screenshot {gif,pdf,png}s on
Linux and OSX.

shamelessly lifted from [here](https://github.com/tmux-plugins/tmux-pain-control/commit/d4d542c)