### PR TITLE
Update goto-session to use fzf auto-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ This plugin solves the above problems.
 
 ### Features
 
-- `prefix + g` - prompts for session name and switches to it. Performs 'kind-of'
-  name completion.<br/>
+- `prefix + g` - prompts for session name and switches to it. Performs
+  auto-completion using fzf.<br/>
   Faster than the built-in `prefix + s` prompt for long session lists.
 - `prefix + C` (shift + c) - prompt for creating a new session by name.
 - `prefix + X` (shift + x) - kill current session without detaching tmux.

--- a/scripts/fzf-tmux-pane.sh
+++ b/scripts/fzf-tmux-pane.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# fzf-tmux: starts fzf in a tmux pane
+# usage: fzf-tmux [-u|-d [HEIGHT[%]]] [-l|-r [WIDTH[%]]] [--] [FZF OPTIONS]
+
+fail() {
+  >&2 echo "$1"
+  exit 2
+}
+
+TMUX_VERSION=$(tmux -V | grep -oE '[0-9]+\.[0-9]*')
+version='3.1'
+if [ ${TMUX_VERSION%.*} -eq ${version%.*} ] && [ ${TMUX_VERSION#*.} \> ${version#*.} ] || [ ${TMUX_VERSION%.*} -gt ${version%.*} ]; then
+  TMUX_FZF_POPUP="${TMUX_FZF_POPUP:-1}"
+else
+  TMUX_FZF_POPUP="${TMUX_FZF_POPUP:-0}"
+fi
+TMUX_FZF_POPUP_HEIGHT=${TMUX_FZF_POPUP_HEIGHT:-38%}
+TMUX_FZF_POPUP_WIDTH=${TMUX_FZF_POPUP_WIDTH:-62%}
+
+fzf="$(command -v fzf 2> /dev/null)" || fzf="$(dirname "$0")/fzf"
+[[ -x "$fzf" ]] || fail 'fzf executable not found'
+
+args=()
+opt=""
+skip=""
+swap=""
+close=""
+term=""
+[[ -n "$LINES" ]] && lines=$LINES || lines=$(tput lines)
+[[ -n "$COLUMNS" ]] && columns=$COLUMNS || columns=$(tput cols)
+
+help() {
+  >&2 echo 'usage: fzf-tmux [-u|-d [HEIGHT[%]]] [-l|-r [WIDTH[%]]] [--] [FZF OPTIONS]
+
+  Layout
+    -u [HEIGHT[%]]  Split above (up)
+    -d [HEIGHT[%]]  Split below (down)
+    -l [WIDTH[%]]   Split left
+    -r [WIDTH[%]]   Split right
+
+    (default: -d 50%)
+'
+  exit
+}
+
+while [[ $# -gt 0 ]]; do
+  arg="$1"
+  shift
+  [[ -z "$skip" ]] && case "$arg" in
+    -)
+      term=1
+      ;;
+    --help)
+      help
+      ;;
+    --version)
+      echo "fzf-tmux (with fzf $("$fzf" --version))"
+      exit
+      ;;
+    -w*|-h*|-d*|-u*|-r*|-l*)
+      if [[ "$arg" =~ ^.[lrw] ]]; then
+        opt="-h"
+        if [[ "$arg" =~ ^.l ]]; then
+          opt="$opt -d"
+          swap="; swap-pane -D ; select-pane -L"
+          close="; tmux swap-pane -D"
+        fi
+      else
+        opt=""
+        if [[ "$arg" =~ ^.u ]]; then
+          opt="$opt -d"
+          swap="; swap-pane -D ; select-pane -U"
+          close="; tmux swap-pane -D"
+        fi
+      fi
+      if [[ ${#arg} -gt 2 ]]; then
+        size="${arg:2}"
+      else
+        if [[ "$1" =~ ^[0-9]+%?$ ]]; then
+          size="$1"
+          shift
+        else
+          continue
+        fi
+      fi
+
+      if [[ "$size" =~ %$ ]]; then
+        size=${size:0:((${#size}-1))}
+        if [[ -n "$swap" ]]; then
+          opt="$opt -p $(( 100 - size ))"
+        else
+          opt="$opt -p $size"
+        fi
+      else
+        if [[ -n "$swap" ]]; then
+          if [[ "$arg" =~ ^.l ]]; then
+            max=$columns
+          else
+            max=$lines
+          fi
+          size=$(( max - size ))
+          [[ $size -lt 0 ]] && size=0
+          opt="$opt -l $size"
+        else
+          opt="$opt -l $size"
+        fi
+      fi
+      ;;
+    --)
+      # "--" can be used to separate fzf-tmux options from fzf options to
+      # avoid conflicts
+      skip=1
+      continue
+      ;;
+    *)
+      args+=("$arg")
+      ;;
+  esac
+  [[ -n "$skip" ]] && args+=("$arg")
+done
+
+if [[ -z "$TMUX" || "$opt" =~ ^-h && "$columns" -le 40 || ! "$opt" =~ ^-h && "$lines" -le 15 ]]; then
+  "$fzf" "${args[@]}"
+  exit $?
+fi
+
+# --height option is not allowed
+args+=("--no-height")
+
+# Handle zoomed tmux pane by moving it to a temp window
+if tmux list-panes -F '#F' | grep -q Z; then
+  zoomed=1
+  original_window=$(tmux display-message -p "#{window_id}")
+  tmp_window=$(tmux new-window -d -P -F "#{window_id}" "bash -c 'while :; do for c in \\| / - '\\;' do sleep 0.2; printf \"\\r\$c fzf-tmux is running\\r\"; done; done'")
+  tmux swap-pane -t $tmp_window \; select-window -t $tmp_window
+fi
+
+set -e
+
+# Clean up named pipes on exit
+id=$RANDOM
+argsf="${TMPDIR:-/tmp}/fzf-args-$id"
+fifo1="${TMPDIR:-/tmp}/fzf-fifo1-$id"
+fifo2="${TMPDIR:-/tmp}/fzf-fifo2-$id"
+fifo3="${TMPDIR:-/tmp}/fzf-fifo3-$id"
+cleanup() {
+  \rm -f $argsf $fifo1 $fifo2 $fifo3
+
+  # Remove temp window if we were zoomed
+  if [[ -n "$zoomed" ]]; then
+    tmux display-message -p "#{window_id}" > /dev/null
+    tmux swap-pane -t $original_window \; \
+      select-window -t $original_window \; \
+      kill-window -t $tmp_window \; \
+      resize-pane -Z
+  fi
+
+  if [ $# -gt 0 ]; then
+    trap - EXIT
+    exit 130
+  fi
+}
+trap 'cleanup 1' SIGUSR1
+trap 'cleanup' EXIT
+
+envs="env TERM=$TERM "
+[[ -n "$FZF_DEFAULT_OPTS"    ]] && envs="$envs FZF_DEFAULT_OPTS=$(printf %q "$FZF_DEFAULT_OPTS")"
+[[ -n "$FZF_DEFAULT_COMMAND" ]] && envs="$envs FZF_DEFAULT_COMMAND=$(printf %q "$FZF_DEFAULT_COMMAND")"
+
+mkfifo -m o+w $fifo2
+mkfifo -m o+w $fifo3
+
+# Build arguments to fzf
+opts=""
+for arg in "${args[@]}"; do
+  arg="${arg//\\/\\\\}"
+  arg="${arg//\"/\\\"}"
+  arg="${arg//\`/\\\`}"
+  arg="${arg//$/\\$}"
+  opts="$opts \"$arg\""
+done
+
+pppid=$$
+echo -n "trap 'kill -SIGUSR1 -$pppid' EXIT SIGINT SIGTERM;" > $argsf
+close="; trap - EXIT SIGINT SIGTERM $close"
+
+if [[ "$TMUX_FZF_POPUP" == 0 ]]; then
+  if [[ -n "$term" ]] || [[ -t 0 ]]; then
+    cat <<< "\"$fzf\" $opts > $fifo2; echo \$? > $fifo3 $close" >> $argsf
+    cat $argsf
+    TMUX=$(echo $TMUX | cut -d , -f 1,2) tmux set-window-option synchronize-panes off \;\
+      set-window-option remain-on-exit off \;\
+      split-window $opt "cd $(printf %q "$PWD");$envs bash $argsf" $swap \
+      > /dev/null 2>&1
+  else
+    mkfifo $fifo1
+    cat <<< "\"$fzf\" $opts < $fifo1 > $fifo2; echo \$? > $fifo3 $close" >> $argsf
+    TMUX=$(echo $TMUX | cut -d , -f 1,2) tmux set-window-option synchronize-panes off \;\
+      set-window-option remain-on-exit off \;\
+      split-window $opt "$envs bash $argsf" $swap \
+      > /dev/null 2>&1
+    cat <&0 > $fifo1 &
+  fi
+  cat $fifo2
+  exit "$(cat $fifo3)"
+else
+  if [[ -n "$term" ]] || [[ -t 0 ]]; then
+      cat <<<"$fzf $opts > $fifo2" >>"$argsf"
+  else
+      mkfifo "$fifo1"
+      cat <<<"$fzf $opts < $fifo1 > $fifo2" >>"$argsf"
+      cat <&0 >$fifo1 &
+  fi
+  cat "$fifo2" &
+  tmux popup -d '#{pane_current_path}' -xC -yC -w$TMUX_FZF_POPUP_WIDTH -h$TMUX_FZF_POPUP_HEIGHT -K -E -R "$envs bash $argsf"
+fi
+

--- a/scripts/goto_session.sh
+++ b/scripts/goto_session.sh
@@ -3,9 +3,6 @@
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 main() {
-	# displayes tmux session list
-	tmux run-shell "$CURRENT_DIR/list_sessions.sh"
-	# goto command prompt
-	tmux command -p session: "run '$CURRENT_DIR/switch_or_loop.sh \"%1\"'"
+	tmux run-shell -b "$CURRENT_DIR/list_sessions.sh | fzf-tmux | xargs $CURRENT_DIR/switch_or_loop.sh"
 }
 main

--- a/scripts/goto_session.sh
+++ b/scripts/goto_session.sh
@@ -3,6 +3,6 @@
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 main() {
-	tmux run-shell -b "$CURRENT_DIR/list_sessions.sh | fzf-tmux | xargs $CURRENT_DIR/switch_or_loop.sh"
+	tmux run-shell -b "$CURRENT_DIR/list_sessions.sh | fzf-tmux | xargs tmux switch-client -t || true"
 }
 main

--- a/scripts/goto_session.sh
+++ b/scripts/goto_session.sh
@@ -3,6 +3,6 @@
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 main() {
-	tmux run-shell -b "$CURRENT_DIR/list_sessions.sh | fzf-tmux | xargs tmux switch-client -t || true"
+	tmux run-shell -b "$CURRENT_DIR/list_sessions.sh | $CURRENT_DIR/fzf-tmux-pane.sh | xargs tmux switch-client -t || true"
 }
 main

--- a/sessionist.tmux
+++ b/sessionist.tmux
@@ -5,7 +5,7 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 default_key_bindings_goto="g"
 tmux_option_goto="@sessionist-goto"
 
-default_key_bindings_alternate="S"
+default_key_bindings_alternate="Tab"
 tmux_option_alternate="@sessionist-alternate"
 
 default_key_bindings_new="C"


### PR DESCRIPTION
Adding to the fzf search introduced by https://github.com/Bakaface/tmux-sessionist,
- Modify goto-session not to send a Ctrl+C to the currently selected pane
- Give goto-session its own tmux pane for fzf search (Credits: https://github.com/sainnhe/tmux-fzf)
- Additionally, https://github.com/Bakaface also replaced alternate sessions keybinding to Tab