### PR TITLE
feat(promotion): autorename session when promoting

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -52,3 +52,9 @@ switch_to_session() {
 	local session_name="$1"
 	tmux switch-client -t "$session_name"
 }
+
+number_of_session_collisions() {
+	tmux -S "$(tmux_socket)" list-sessions | grep -c "$1" 
+	# this is a temporary implementation, a session might have a similar name or have a name with a higher value than the number of collision
+	# I need help fixing those potential issues
+}

--- a/scripts/promote_pane.sh
+++ b/scripts/promote_pane.sh
@@ -7,6 +7,7 @@ source "$CURRENT_DIR/helpers.sh"
 # global vars passed to the script as arguments
 CURRENT_SESSION_ID="$1"
 CURRENT_PANE_ID="$2"
+PANE_CURRENT_COMMAND="$3"
 PANE_CURRENT_PATH="$4"
 
 number_of_panes() {
@@ -24,6 +25,16 @@ new_session_pane_id() {
 	tmux list-panes -t "$session_id" -F "#{pane_id}"
 }
 
+rename_session_to_pane() {
+	local new_session_name="$PANE_CURRENT_COMMAND"
+	[ "$new_session_name" == "tmux" ] &&
+		new_session_name="$(echo "$PANE_CURRENT_PATH" | sed 's/.*\/\([^/]*\)$/\1/')"
+	[ -z "$new_session_name" ] &&
+		new_session_name="/"
+	name_collisions="$(number_of_session_collisions "$new_session_name")"
+	[ "$name_collisions" -gt 0 ] &&
+		new_session_name="$new_session_name-$((name_collisions+1))"
+  tmux rename-session -t "$1" "$new_session_name"
 }
 
 promote_pane() {
@@ -31,6 +42,7 @@ promote_pane() {
 	local new_session_pane_id="$(new_session_pane_id "$session_id")"
 	tmux swap-pane -s "$CURRENT_PANE_ID" -t "$new_session_pane_id"
 	tmux kill-pane -t "$new_session_pane_id"
+	rename_session_to_pane "$session_id"
 	switch_to_session "$session_id"
 }
 

--- a/scripts/promote_pane.sh
+++ b/scripts/promote_pane.sh
@@ -27,10 +27,6 @@ new_session_pane_id() {
 
 rename_session_to_pane() {
 	local new_session_name="$PANE_CURRENT_COMMAND"
-	[ "$new_session_name" == "tmux" ] &&
-		new_session_name="$(echo "$PANE_CURRENT_PATH" | sed 's/.*\/\([^/]*\)$/\1/')"
-	[ -z "$new_session_name" ] &&
-		new_session_name="/"
 	name_collisions="$(number_of_session_collisions "$new_session_name")"
 	[ "$name_collisions" -gt 0 ] &&
 		new_session_name="$new_session_name-$((name_collisions+1))"

--- a/scripts/promote_pane.sh
+++ b/scripts/promote_pane.sh
@@ -27,7 +27,7 @@ new_session_pane_id() {
 promote_pane() {
 	local session_name="$(create_new_session)"
 	local new_session_pane_id="$(new_session_pane_id "$session_name")"
-	tmux join-pane -s "$CURRENT_PANE_ID" -t "$new_session_pane_id"
+	tmux swap-pane -s "$CURRENT_PANE_ID" -t "$new_session_pane_id"
 	tmux kill-pane -t "$new_session_pane_id"
 	switch_to_session "$session_name"
 }

--- a/scripts/promote_pane.sh
+++ b/scripts/promote_pane.sh
@@ -5,31 +5,33 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"
 
 # global vars passed to the script as arguments
-CURRENT_SESSION_NAME="$1"
+CURRENT_SESSION_ID="$1"
 CURRENT_PANE_ID="$2"
-PANE_CURRENT_PATH="$3"
+PANE_CURRENT_PATH="$4"
 
 number_of_panes() {
-	tmux list-panes -s -t "$CURRENT_SESSION_NAME" |
+	tmux list-panes -s -t "$CURRENT_SESSION_ID" |
 		wc -l |
 		tr -d ' '
 }
 
 create_new_session() {
-	TMUX="" tmux -S "$(tmux_socket)" new-session -c "$PANE_CURRENT_PATH" -d -P -F "#{session_name}"
+	TMUX="" tmux -S "$(tmux_socket)" new-session -c "$PANE_CURRENT_PATH" -d -P -F "#{session_id}"
 }
 
 new_session_pane_id() {
-	local session_name="$1"
-	tmux list-panes -t "$session_name" -F "#{pane_id}"
+	local session_id="$1"
+	tmux list-panes -t "$session_id" -F "#{pane_id}"
+}
+
 }
 
 promote_pane() {
-	local session_name="$(create_new_session)"
-	local new_session_pane_id="$(new_session_pane_id "$session_name")"
+	local session_id="$(create_new_session)"
+	local new_session_pane_id="$(new_session_pane_id "$session_id")"
 	tmux swap-pane -s "$CURRENT_PANE_ID" -t "$new_session_pane_id"
 	tmux kill-pane -t "$new_session_pane_id"
-	switch_to_session "$session_name"
+	switch_to_session "$session_id"
 }
 
 main() {

--- a/scripts/promote_window.sh
+++ b/scripts/promote_window.sh
@@ -25,6 +25,12 @@ new_session_window_id() {
 	tmux list-windows -t "$session_id" -F "#{window_id}"
 }
 
+rename_session_to_window() {
+	local new_session_name="$CURRENT_WINDOW_NAME"
+	name_collisions="$(number_of_session_collisions "$new_session_name")"
+	[ "$name_collisions" -gt 0 ] &&
+		new_session_name="$new_session_name-$((name_collisions+1))"
+  tmux rename-session -t "$1" "$new_session_name"
 }
 
 promote_window() {
@@ -32,6 +38,7 @@ promote_window() {
 	local new_session_window_id="$(new_session_window_id "$session_id")"
 	tmux swap-window -s "$CURRENT_WINDOW_ID" -t "$new_session_window_id"
 	tmux kill-window -t "$new_session_window_id"
+	rename_session_to_window "$session_id"
 	switch_to_session "$session_id"
 }
 

--- a/scripts/promote_window.sh
+++ b/scripts/promote_window.sh
@@ -5,32 +5,34 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"
 
 # global vars passed to the script as arguments
-CURRENT_SESSION_NAME="$1"
+CURRENT_SESSION_ID="$1"
 CURRENT_WINDOW_ID="$2"
 CURRENT_WINDOW_NAME="$3"
 WINDOW_CURRENT_PATH="$4"
 
 number_of_windows() {
-	tmux list-windows -t "$CURRENT_SESSION_NAME" |
+	tmux list-windows -t "$CURRENT_SESSION_ID" |
 		wc -l |
 		tr -d ' '
 }
 
 create_new_session() {
-	TMUX="" tmux -S "$(tmux_socket)" new-session -c "$WINDOW_CURRENT_PATH" -s "$CURRENT_WINDOW_NAME" -d -P -F "#{session_name}"
+	TMUX="" tmux -S "$(tmux_socket)" new-session -c "$WINDOW_CURRENT_PATH" -d -P -F "#{session_id}"
 }
 
 new_session_window_id() {
-	local session_name="$1"
-	tmux list-windows -t "$session_name" -F "#{window_id}"
+	local session_id="$1"
+	tmux list-windows -t "$session_id" -F "#{window_id}"
+}
+
 }
 
 promote_window() {
-	local session_name="$(create_new_session)"
-	local new_session_window_id="$(new_session_window_id "$session_name")"
+	local session_id="$(create_new_session)"
+	local new_session_window_id="$(new_session_window_id "$session_id")"
 	tmux swap-window -s "$CURRENT_WINDOW_ID" -t "$new_session_window_id"
 	tmux kill-window -t "$new_session_window_id"
-	switch_to_session "$session_name"
+	switch_to_session "$session_id"
 }
 
 main() {

--- a/sessionist.tmux
+++ b/sessionist.tmux
@@ -58,7 +58,7 @@ set_promote_pane_binding() {
 	local key_bindings=$(get_tmux_option "$tmux_option_promote_pane" "$default_key_bindings_promote_pane")
 	local key
 	for key in $key_bindings; do
-		tmux bind "$key" run "$CURRENT_DIR/scripts/promote_pane.sh '#{session_name}' '#{pane_id}' '#{pane_current_path}'"
+		tmux bind "$key" run "$CURRENT_DIR/scripts/promote_pane.sh '#{session_id}' '#{pane_id}' '#{pane_current_command}' '#{pane_current_path}'"
 	done
 }
 
@@ -67,7 +67,7 @@ set_promote_window_binding() {
 	local key_bindings=$(get_tmux_option "$tmux_option_promote_window" "$default_key_bindings_promote_window")
 	local key
 	for key in $key_bindings; do
-		tmux bind "$key" run "$CURRENT_DIR/scripts/promote_window.sh '#{session_name}' '#{window_id}' '#{window_name}' '#{pane_current_path}'"
+		tmux bind "$key" run "$CURRENT_DIR/scripts/promote_window.sh '#{session_id}' '#{window_id}' '#{window_name}' '#{pane_current_path}'"
 	done
 }
 


### PR DESCRIPTION
perf(promotion): pane swapping instead of joining
refactor(promotion): use IDs instead of names

---

See [scritps/helpers.sh:58](https://github.com/TheSast/tmux-sessionist/blob/829a032ea6b33633b4ebb3eec05f65bf217f18c9/scripts/helpers.sh#L58) before merging.