### PR TITLE
feat: added @sessionist-maintain-path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ This plugin solves the above problems.
     - `v`, `|`, `%`: join vertically
     - `f`, `@`: join full screen
 
+### Configuration
+
+If you wish for sessions created by promoting a pane or window use their path add this to `.tmux.conf`:
+
+    set -g @sessionist-maintain-path 'on'
+
 ### Installation with [Tmux Plugin Manager](https://github.com/tmux-plugins/tpm) (recommended)
 
 Add plugin to the list of TPM plugins in `.tmux.conf`:

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -52,3 +52,11 @@ switch_to_session() {
 	local session_name="$1"
 	tmux switch-client -t "$session_name"
 }
+
+create_session() {
+	if [ "$(get_tmux_option "@sessionist-maintain-path")" == "on" ]; then
+		TMUX="" tmux -S "$(tmux_socket)" new-session -c "$1" -d -P -F "#{session_id}"
+	else
+		TMUX="" tmux -S "$(tmux_socket)" new-session         -d -P -F "#{session_id}"
+	fi
+}

--- a/scripts/new_session.sh
+++ b/scripts/new_session.sh
@@ -11,6 +11,14 @@ session_name_not_provided() {
 	[ -z "$SESSION_NAME" ]
 }
 
+create_named_session() {
+	if [ "$(get_tmux_option "@sessionist-maintain-path")" == "on" ]; then
+		TMUX="" tmux -S "$(tmux_socket)" new-session -c "$1" -s "$2" -d -P -F "#{session_id}"
+	else
+		TMUX="" tmux -S "$(tmux_socket)" new-session         -s "$2" -d -P -F "#{session_id}"
+	fi
+}
+
 create_new_tmux_session() {
 	if session_name_not_provided; then
 		exit 0
@@ -21,7 +29,7 @@ create_new_tmux_session() {
 		# New session name may differ from the input. Eg input name may be
 		# 'foo.bar', but new name will be 'foo_bar'.
 		local pane_current_path=$(tmux display-message -p "#{pane_current_path}")
-		local session_id=$(create_session "$pane_current_path")
+		local session_id=$(create_named_session "$pane_current_path" "$SESSION_NAME")
 		switch_to_session "$session_id"
 	fi
 }

--- a/scripts/new_session.sh
+++ b/scripts/new_session.sh
@@ -20,11 +20,9 @@ create_new_tmux_session() {
 	else
 		# New session name may differ from the input. Eg input name may be
 		# 'foo.bar', but new name will be 'foo_bar'.
-		#
-		# -c "#{pane_current_path}" has to be specified, otherwise a random path is
-		# used for the new session.
-		local session_name=$(TMUX="" tmux -S "$(tmux_socket)" new-session -d -P -c "#{pane_current_path}" -s "$SESSION_NAME")
-		switch_to_session "$session_name"
+		local pane_current_path=$(tmux display-message -p "#{pane_current_path}")
+		local session_id=$(create_session "$pane_current_path")
+		switch_to_session "$session_id"
 	fi
 }
 

--- a/scripts/promote_pane.sh
+++ b/scripts/promote_pane.sh
@@ -25,11 +25,11 @@ new_session_pane_id() {
 }
 
 promote_pane() {
-	local session_name="$(create_new_session)"
-	local new_session_pane_id="$(new_session_pane_id "$session_name")"
+	local session_id="$(create_session "$PANE_CURRENT_PATH")"
+	local new_session_pane_id="$(new_session_pane_id "$session_id")"
 	tmux join-pane -s "$CURRENT_PANE_ID" -t "$new_session_pane_id"
 	tmux kill-pane -t "$new_session_pane_id"
-	switch_to_session "$session_name"
+	switch_to_session "$session_id"
 }
 
 main() {

--- a/scripts/promote_window.sh
+++ b/scripts/promote_window.sh
@@ -26,11 +26,11 @@ new_session_window_id() {
 }
 
 promote_window() {
-	local session_name="$(create_new_session)"
-	local new_session_window_id="$(new_session_window_id "$session_name")"
+	local session_id="$(create_session "$WINDOW_CURRENT_PATH")"
+	local new_session_window_id="$(new_session_window_id "$session_id")"
 	tmux swap-window -s "$CURRENT_WINDOW_ID" -t "$new_session_window_id"
 	tmux kill-window -t "$new_session_window_id"
-	switch_to_session "$session_name"
+	switch_to_session "$session_id"
 }
 
 main() {


### PR DESCRIPTION
docs: added how to set @sessionist-maintain-path

---

Option to maintain the path currently open in the shell when creating a new session (weather trough promotion or not)
Resolves #4
Alternative that closes #5
Related to #23 and #24 